### PR TITLE
hal: hack: Add nrf_hack function for triggering a task based on an addr

### DIFF
--- a/make_inc/52833_hal_files
+++ b/make_inc/52833_hal_files
@@ -17,3 +17,4 @@ src/nrfx/hal/nrf_ppi.c
 src/nrfx/hal/nrf_ecb.c
 src/nrfx/hal/nrf_uart.c
 src/nrfx/hal/nrf_uarte.c
+src/nrfx/hal/nrf_hack.c


### PR DESCRIPTION
Add nrf_hack_trigger_task_address(), which can be used to trigger a task in a HW model simply based on its address, without knowing what peripheral it belongs to.