### PR TITLE
RTC/GRTC: Provide APIs that return the start time

### DIFF
--- a/src/HW_models/NHW_GRTC.c
+++ b/src/HW_models/NHW_GRTC.c
@@ -183,7 +183,7 @@ static inline void nhw_GRTC_check_valid_domain_index(uint inst, uint nbr, const 
 }
 
 
-static bs_time_t nhw_GRTC_counter_to_time(uint inst, uint64_t value) {
+bs_time_t nhw_GRTC_counter_to_time(uint inst, uint64_t value) {
   (void) inst;
   return value + nhw_grtc_st.GRTC_start_time;
 }

--- a/src/HW_models/NHW_GRTC.h
+++ b/src/HW_models/NHW_GRTC.h
@@ -39,6 +39,19 @@ void nhw_GRTC_regw_sideeffects_CC_CCH(uint inst, uint cc);
 uint32_t nhw_GRTC_regr_sideeffects_SYSCOUNTERL(uint inst, uint n);
 uint32_t nhw_GRTC_regr_sideeffects_SYSCOUNTERH(uint inst, uint n);
 
+
+/** Return the time for a given GRTC counter value.
+ *
+ * This function can be used to compare GRTC-based timestamps
+ * from different bsim instances.
+ *
+ * @param inst GRTC instance
+ * @param value The GRTC value
+ * 
+ * @returns The timestamp corresponding to a given GRTC value.
+ */
+bs_time_t nhw_GRTC_counter_to_time(uint inst, uint64_t value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/HW_models/NHW_RTC.c
+++ b/src/HW_models/NHW_RTC.c
@@ -879,3 +879,18 @@ void nhw_rtc2_TASKS_STOP(void)       { nhw_rtc_TASKS_STOP(2);  }
 void nhw_rtc2_TASKS_CLEAR(void)      { nhw_rtc_TASKS_CLEAR(2); }
 void nhw_rtc2_TASKS_TRIGOVRFLW(void) { nhw_rtc_TASKS_TRIGOVRFLW(2); }
 #endif /* NHW_HAS_PPI */
+
+int64_t nhw_rtc_start_time_get(uint rtc) {
+  struct rtc_status *this = &nhw_rtc_st[rtc];
+
+  if (!this->running) {
+    bs_trace_error_time_line("RTC is not running. Start time unknown\n");
+    return 0;
+  }
+
+  if(this->counter_startT_sub_us > 0) {
+    return (int64_t)sub_us_time_to_us_time(this->counter_startT_sub_us);
+  } else {
+    return -(int64_t)sub_us_time_to_us_time(this->counter_startT_negative_sub_us); 
+  }
+}

--- a/src/HW_models/NHW_RTC.h
+++ b/src/HW_models/NHW_RTC.h
@@ -47,6 +47,19 @@ void nhw_rtc2_TASKS_CLEAR(void);
 void nhw_rtc2_TASKS_TRIGOVRFLW(void);
 #endif /* NHW_HAS_PPI */
 
+/** Return the time when the provided RTC started.
+ *
+ * This function can be used to compare RTC-based timestamps
+ * from different bsim instances.
+ *
+ * @param rtc RTC index
+ * 
+ * @returns The timestamp where the RTC started.
+ *          The value is negative if the counter started
+ *          before the device time was 0.
+ */
+int64_t nhw_rtc_start_time_get(uint rtc);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
These API allows us to convert RTC/GRTC-based time to bs_time. We want to use this API to allow comparing GRTC-based timestamps from different bsim instances to verify that some given action is synchronized. For example, timestamps provided in isochronous channels data packets