### PR TITLE
zephyr: module.yml: add `depends` field

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if(CONFIG_SOC_SERIES_BSIM_NRFXX)
   if(CONFIG_SOC_SERIES_BSIM_NRF52X)
     file(STRINGS make_inc/52833_hw_files HW_MODEL_SRCS)
     file(STRINGS make_inc/52833_hal_files HAL_SRCS)
-    set(VARIANT_FLAGS 
+    set(VARIANT_FLAGS
         -DNRF52833_XXAA
         -DNRF52833
     )
@@ -76,7 +76,7 @@ if(CONFIG_SOC_SERIES_BSIM_NRFXX)
   # The HW models are built in the runner context, so they have access to the host OS
   target_sources(native_simulator INTERFACE ${HW_MODEL_SRCS})
 
-  target_compile_options(native_simulator BEFORE INTERFACE 
+  target_compile_options(native_simulator BEFORE INTERFACE
     -I${NSI_DIR}/common/src/include
     -I${NSI_DIR}/common/src/
     -I$ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,2 +1,4 @@
 build:
   cmake: .
+  depends:
+    - hal_nordic


### PR DESCRIPTION
The core `CMakeLists.txt` file depends on `NRFX_DIR` being defined,
which is only done in the `hal_nordic` module. By chance the upstream
Zephyr cmake processing is in the right order, but this is not
guaranteed in other manifest setups.
