### PR TITLE
HW_models: NHW_NVMC: fix buffer read validation

### DIFF
--- a/src/HW_models/NHW_NVMC.c
+++ b/src/HW_models/NHW_NVMC.c
@@ -627,7 +627,7 @@ void nhw_nmvc_read_buffer(void *dest, uint32_t address, size_t size) {
     }
   }
 
-  if (offset + size >= backend->size) {
+  if (offset + size > backend->size) {
     OUT_OF_FLASH_ERROR(address + size);
   }
 


### PR DESCRIPTION
The address validation in `nhw_nmvc_read_buffer` should only fail if the address goes past the end of flash, not to the very end of flash. For example, a 1 byte read at address `0x7FFFF` should be fine, but the previous check would fail.

This affects trying to use the storage partition as a NVS backend.