### PR TITLE
RTC: Set compare register even without any interrupts enabled

### DIFF
--- a/src/HW_models/NHW_RTC.c
+++ b/src/HW_models/NHW_RTC.c
@@ -611,13 +611,14 @@ static void nhw_rtc_signal_COMPARE(uint rtc, uint cc)
   }
 #endif /* NHW_RTC_HAS_SHORT_COMP_CLEAR */
 
+  /* Compare register can be set without any interrupts enabled. */
+  RTC_regs->EVENTS_COMPARE[cc] = 1;
+
   uint32_t mask = RTC_EVTEN_COMPARE0_Msk << cc;
 
   if (!((RTC_regs->EVTEN | this->INTEN) & mask)) {
     return;
   }
-
-  RTC_regs->EVENTS_COMPARE[cc] = 1;
 
   if (RTC_regs->EVTEN & mask) {
 #if (NHW_HAS_PPI)


### PR DESCRIPTION
The RTC signal compare would only set the register if there were interrupts enabled for that CC. This is not the behavior of the hardware which will write to the register even without any interrupts enabled.