### PR TITLE
Fix wrong NRF_UARTE register reference

### DIFF
--- a/src/HW_models/NHW_UART.c
+++ b/src/HW_models/NHW_UART.c
@@ -642,7 +642,7 @@ static void nhw_UARTE_RxDMA_start(int inst) {
   u_el->rx_dma_status = DMAing;
 #if NHW_UARTE_HAS_MATCH
     for (int i = 0; i < u_el->n_match; i++) {
-      u_el->MATCH_CANDIDATE[i] = NRF_UARTE_regs[i].DMA.RX.MATCH.CANDIDATE[i];
+      u_el->MATCH_CANDIDATE[i] = NRF_UARTE_regs[inst].DMA.RX.MATCH.CANDIDATE[i];
     }
 #endif
   nhw_UARTE_signal_EVENTS_RXSTARTED(inst); /* Instantaneously ready */


### PR DESCRIPTION
There was an issue where the match candidate was read from the wrong NRF_UARTE instance. If the number of match candidates and the number of uarte instances is different, this would lead to an invalid memory access.