### PR TITLE
hal: use original nrf_uicr.h

### DIFF
--- a/src/nrfx/hal/nrf_hal_originals.c
+++ b/src/nrfx/hal/nrf_hal_originals.c
@@ -247,6 +247,10 @@
 #include "hal/nrf_uarte.h"
 #endif
 
+#ifdef UICR_PRESENT
+#include "hal/nrf_uicr.h"
+#endif
+
 #ifdef USBD_PRESENT
 #include "hal/nrf_usbd.h"
 #endif


### PR DESCRIPTION
NRFX version 4.2.0 added new function nrf_uicr_fits_check, which is used in:
- nrfx_nvmc.c
- nrfx_mramc.c
- nrfx_rramc.c

Without the function, linking fails.